### PR TITLE
Update the powershell script to handle window closures for MFA login

### DIFF
--- a/Authorization Code Grant Flow/LoginBrowser.psm1
+++ b/Authorization Code Grant Flow/LoginBrowser.psm1
@@ -6,6 +6,32 @@ Add-Type -AssemblyName System.Web
 $outputAuth = ".\Code.txt"
 $outputError = ".\Error.txt"
 
+function Add-NativeHelperType
+{
+    $nativeHelperTypeDefinition =
+    @"
+    using System;
+    using System.Runtime.InteropServices;
+
+    public static class NativeHelper
+        {
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        public static bool SetForeground(IntPtr windowHandle)
+        {
+           return NativeHelper.SetForegroundWindow(windowHandle);
+        }
+
+    }
+"@
+    if(-not ([System.Management.Automation.PSTypeName] "NativeHelper").Type)
+    {
+        Add-Type -TypeDefinition $nativeHelperTypeDefinition
+    }
+}
+
 function LoginBrowser
 {
     param
@@ -19,7 +45,8 @@ function LoginBrowser
         [uri]$redirectUri
     )
 
-	# Create an Internet Explorer Window for the Login Experience
+    Add-NativeHelperType
+    # Create an Internet Explorer Window for the Login Experience
     $ie = New-Object -ComObject InternetExplorer.Application
     $ie.Width = 600
     $ie.Height = 500
@@ -28,34 +55,66 @@ function LoginBrowser
     $ie.StatusBar = $false
     $ie.visible = $true
     $ie.navigate($authorizationUrl)
+    $handle = $ie.HWND
+    $winForeground = [NativeHelper]::SetForeground($handle)
+    # Grab the window
+    $wind = (New-Object -ComObject Shell.Application).Windows() | Where-Object { $_.HWND -eq $handle }
+    $sleepCounter = 0
 
-    while ($ie.Busy) {} 
+    while ($ie.Busy)
+    {
+        Start-Sleep -Milliseconds 50
+        $sleepCounter++
 
-    :loop while($true)
-    {   
-		# Grab URL in IE Window
-        $urls = (New-Object -ComObject Shell.Application).Windows() | Where-Object {($_.LocationUrl -match "(^https?://.+)|(^ftp://)") -and ($_.HWND -eq $ie.HWND)} | Where-Object {$_.LocationUrl}
-
-        foreach ($a in $urls)
+        if ($sleepCounter -eq 100)
         {
-			# If URL is in the form we expect, with the Reply URL as the domain, and the code in the URL, grab the code
-            if (($a.LocationUrl).StartsWith($redirectUri.ToString()+"?code="))
-            {
-                $code = ($a.LocationUrl)
-                ($code = $code -replace (".*code=") -replace ("&.*")) | Out-File $outputAuth
-                break loop
-            }
-			# If we catch an error, output the error information
-			elseif (($a.LocationUrl).StartsWith($redirectUri.ToString()+"?error="))
-            {
-                $error = [System.Web.HttpUtility]::UrlDecode(($a.LocationUrl) -replace (".*error="))
-                $error | Out-File $outputError
-                break loop
-            }
+            throw "Unable to connect to $authorizationUrl, timed out waiting for page."
         }
     }
 
-	# Return the Auth Code
-    return $code
+    try
+    {
+        while($true)
+        {
+            $urls = @()
+            $urls += $wind.LocationUrl | Where-Object { $_ -and $_ -match "(^https?://.+)|(^ftp://)" }
+            if (-not $urls) 
+            {
+                # "No urls found, refreshing window"
+                $wind = (New-Object -ComObject Shell.Application).Windows() | Where-Object { $_.HWND -eq $handle }
+                if (-not $wind)
+                {
+                    throw "Could not find IE window with handle: $handle"
+                }
+            }
+            
+            foreach ($url in $urls)
+            {
+                if (($url).StartsWith($RedirectUri.ToString()+"?code="))
+                {
+                    ($code = $url -replace (".*code=") -replace ("&.*"))  | Out-File $outputAuth
+                    return $code
+                }
+                elseif (($url).StartsWith($RedirectUri.ToString()+"?error="))
+                {
+                    $error = [System.Web.HttpUtility]::UrlDecode(($a.LocationUrl) -replace (".*error="))
+                    $error | Out-File $outputError
+                    return
+                }
+            }
+        }
+    }
+    finally
+    {
+        if (-not $wind)
+        {
+            $wind = (New-Object -ComObject Shell.Application).Windows() | Where-Object { $_.HWND -eq $handle }
+        }
+        
+        if ($wind)
+        {
+            $wind.Quit()
+        }
+    }
 }
 


### PR DESCRIPTION
During the IE login using an account that is MFA enabled I found that the script did not extract the authorization code. I found out that following line did not catch any urls after MFA login:
$urls = (New-Object -ComObject Shell.Application).Windows() | Where-Object {($_.LocationUrl -match "(^https?://.+)|(^ftp://)") -and ($_.HWND -eq $ie.HWND)} | Where-Object {$_.LocationUrl}

because ($_.HWND -eq $ie.HWND) condition was not working as $ie was null when the window restarted.
The IE window in the end still hangs around some times after the code is extracted.